### PR TITLE
fix: fetch pending order item path

### DIFF
--- a/lib/desertcart/marketplace/pending_order_items/searcher.rb
+++ b/lib/desertcart/marketplace/pending_order_items/searcher.rb
@@ -15,6 +15,10 @@ module Desertcart
         def ledger_resource_type
           @ledger_resource_type ||= 'pending_order_items'
         end
+
+        def ledger_namespace_path
+          'marketplace'
+        end
       end
     end
   end


### PR DESCRIPTION
This fixes the url path created for pending_order_items. In this particular case we have overridden the resource class, as such we need to specify namespace explicitly.