### PR TITLE
Add allow_store_switching attribute

### DIFF
--- a/lib/desertcart/marketplace/order_item/deserializer.rb
+++ b/lib/desertcart/marketplace/order_item/deserializer.rb
@@ -32,6 +32,7 @@ module Desertcart
         attribute :accepted_at
         attribute :purchase_order
         attribute :note
+        attribute :allow_store_switching
         references_one :shipping_address,
                        hash_attribute: 'shipping_address',
                        deserializer: ShippingAddress::Deserializer

--- a/lib/desertcart/marketplace/order_item/serializer.rb
+++ b/lib/desertcart/marketplace/order_item/serializer.rb
@@ -31,6 +31,7 @@ module Desertcart
         attribute :purchase_order
         attribute :shipping_address
         attribute :note
+        attribute :allow_store_switching
       end
     end
   end

--- a/lib/desertcart/resources/marketplace/order_item.rb
+++ b/lib/desertcart/resources/marketplace/order_item.rb
@@ -30,6 +30,7 @@ module Desertcart
       attribute :accepted_at, type: LedgerSync::Type::Integer
       attribute :purchase_order, type: LedgerSync::Type::String
       attribute :note, type: LedgerSync::Type::String
+      attribute :allow_store_switching, type: LedgerSync::Type::Boolean
       references_one :shipping_address,
                      to: Desertcart::Marketplace::ShippingAddress
     end


### PR DESCRIPTION
I'm not sure about why we added that much attributes to the `serializer` here. So I added the new attribute to there.
For the `deserializer` all good.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new attribute to order items that indicates whether store switching is allowed. This attribute is now visible in order item details and included in related data displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->