### PR TITLE
DC API Root URI changed

### DIFF
--- a/lib/desertcart/client.rb
+++ b/lib/desertcart/client.rb
@@ -4,7 +4,7 @@ module Desertcart
   class Client
     include LedgerSync::Ledgers::Client::Mixin
 
-    ROOT_URI = 'https://api.desertcart.com/api'
+    ROOT_URI = 'https://desertcart.ae/api'
 
     REQUEST_HEADERS = { 'Accept' => 'application/vnd.api+json; version:3.0',
                         'Content-Type' => 'application/json' }.freeze


### PR DESCRIPTION
We started to have issues on DB during sync with DC: `Couldn't resolve host name`.

The URI changed to `desertcart.ae/api`

Issue slack: https://desertcartuae.slack.com/archives/C037UTHFU4W/p1755679371967219
Example: https://dropbot.sh/admin/trail/logs/68a593f1d991130007a70c5a

<img width="843" height="494" alt="Screenshot 2025-08-20 at 13 29 45" src="https://github.com/user-attachments/assets/e5ff5e95-a177-406e-8703-a64f93b9e3d3" />
